### PR TITLE
chore: permit ops versions >= 2.16

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1701,4 +1701,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "cee3ac1602e98927b9545798e10ec8284d7f73a41f7c92283f4cab390d8ed009"
+content-hash = "0dd25b9fd744d588485dc3a7eeee28db53cb01a80c3166d091090e0e6308bf07"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.10,<4.0"
 
 dependencies = [
     "poetry-core (>=2.0)",
-    "ops (~=2.15.0)",
+    "ops (~=2.15)",
     "overrides (~=7.7.0)",
     "cryptography (~=42.0.5)",  # tls_certificates lib v3
     "jsonschema (~=4.22.0)",  # tls_certificates lib v3


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [x] Dependencies upgrade or change

## 📝 Description
This PR allows this library to be used with charms specifying an `ops` version `>=2.16`.

I noticed that this library specifies `ops` version `~=2.15.0` when trying to run the unit tests of a charm that depends on this library with the latest ops release (which we do in CI to help us avoid breaking changes). The `~=` version specifier's behaviour depends on the precision with which you specify the version, so `~=2.15.0` translates to `>=2.15.0,<2.16`.  

Assuming that this library doesn't need to be so restrictive with its `ops` version, this PR sets the `ops` version to `~=2.15`, which effectively translates to `>=2.15,<3`.
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

## 📑 Motivation and Context
This will allow charms that depend on this library to use ops versions `>=2.16`. This seems good in general, and will also make it easier for us to test the compatibility of new ops releases with charms that depend on this library.
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

## 🧪 How Has This Been Tested?
I've created a separate branch to check that CI still passes with the latest `ops` (`2.18.1`).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
